### PR TITLE
add setup.py allowing for building packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url="https://github.com/peerdavid/remapy",
     author="Peer David",
     author_email="TODO",
-    packages=find_packages(where=".") + ["."],
+    packages=find_packages(where="."),
     python_requires=">=3.6, <4",
     install_requires=[
         "numpy",
@@ -25,7 +25,7 @@ setup(
         "requests",
     ],
     package_data={
-        "remapy": ["gui/icons/*.png"],
+        "gui": ["icons/*.png"],
     },
     entry_points={
         "gui_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+from setuptools import setup, find_packages
+import pathlib
+
+here = pathlib.Path(__file__).parent.resolve()
+
+long_description = (here / "README.md").read_text(encoding="utf-8")
+
+setup(
+    name="remapy",
+    version="0.5.0",
+    description="An open source file exporer for your reMarkable tablet.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/peerdavid/remapy",
+    author="Peer David",
+    author_email="TODO",
+    packages=find_packages(where=".") + ["."],
+    python_requires=">=3.6, <4",
+    install_requires=[
+        "numpy",
+        "Pillow",
+        "pdfrw",
+        "pyyaml",
+        "reportlab",
+        "requests",
+    ],
+    package_data={
+        "remapy": ["gui/icons/*.png"],
+    },
+    entry_points={
+        "gui_scripts": [
+            "remapy=rema:main",
+        ],
+    },
+    project_urls={
+        "Bug Reports": "https://github.com/peerdavid/remapy/issues",
+        "Source": "https://github.com/peerdavid/remapy",
+    },
+)


### PR DESCRIPTION
Added a minimal `setup.py` file which will allow the project to be built as a wheel, and ultimately distributed/installed via PyPI and pip (this also makes it easier to package for various Linux package managers).

@peerdavid I filled in your info, but couldn't find a good email address for you. Happy to add one, or remove the field (it's optional). Also, I set the version number as 0.5.0, but it can be set to whatever you like.

I tested locally and I was able to install via the local wheel file. To test it out locally: 
```
$ pip install wheel                                # ensure wheel is installed
$ python setup.py bdist_wheel                      # build the wheel file
$ pip install dist/remapy-0.5.0-py3-none-any.whl   # install the built wheel file
$ remapy                                           # run remapy! requires $HOME/.local/bin to be on PATH if installing to user location
```