### PR TITLE
UpdatedDependency: move to pathlib2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ pyyaml
 requests
 pdfrw
 reportlab
-pathlib
+pathlib2
 wheel
+


### PR DESCRIPTION
I had to move `pathlib` to the newer release `pathlib2`
I was not able to install the "old" pathlib module

Now its up and running again
